### PR TITLE
Need LaTeXStrings to import Qlab

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,4 +7,3 @@ StatsBase
 QuantumTomography
 KernelDensity
 PyPlot
-LaTeXStrings

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ StatsBase
 QuantumTomography
 KernelDensity
 PyPlot
+LaTeXStrings

--- a/src/Qlab.jl
+++ b/src/Qlab.jl
@@ -1,5 +1,5 @@
 module Qlab
-	using Compat
+	using Compat, LaTeXStrings
 
 	export load_data, KT_estimation, pauliAlphabet, filter_records, comp_to_paulis, savitsky_golay, read_records, digitize
 

--- a/src/Qlab.jl
+++ b/src/Qlab.jl
@@ -1,5 +1,5 @@
 module Qlab
-	using Compat, LaTeXStrings
+	using Compat, PyPlot
 
 	export load_data, KT_estimation, pauliAlphabet, filter_records, comp_to_paulis, savitsky_golay, read_records, digitize
 


### PR DESCRIPTION
Adding LaTeXStrings to REQUIRE.  I still can't import Qlab without doing this in 0.5 or 0.6.  Is anyone else having this problem?